### PR TITLE
Added `ShowItemInfo()` and `ShowSetInfo()` exports

### DIFF
--- a/src/Exports/Export.as
+++ b/src/Exports/Export.as
@@ -1,3 +1,7 @@
 namespace ItemExchange {
     import void ImportUnloadedItems() from "ItemExchange";
+
+    import void ShowItemInfo(int itemID) from "ItemExchange";
+
+    import void ShowSetInfo(int setID) from "ItemExchange";
 }

--- a/src/Exports/ExportFunctions.as
+++ b/src/Exports/ExportFunctions.as
@@ -2,4 +2,14 @@ namespace ItemExchange {
     void ImportUnloadedItems() {
         Work::ImportUnloaded();
     }
+
+    void ShowItemInfo(int itemID) {
+        if (!ixMenu.isOpened) ixMenu.isOpened = true;
+        ixMenu.AddTab(ItemTab(itemID), true);
+    }
+
+    void ShowSetInfo(int setID) {
+        if (!ixMenu.isOpened) ixMenu.isOpened = true;
+        ixMenu.AddTab(ItemSetTab(setID), true);
+    }
 }


### PR DESCRIPTION
Added there exports to have a possibility to integrate ManiaExchange's `MapInfo` embedded items tab into ItemExchange's `ItemInfo` as optional dependency